### PR TITLE
[Fix]: White Pen Not Visible in AI Response

### DIFF
--- a/src/components/ResponseDialog.tsx
+++ b/src/components/ResponseDialog.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import { Copy, Download, Maximize, Minimize, X } from "lucide-react";
 import type React from "react";
 import { useEffect, useRef, useState } from "react";
-import { X, Download, Maximize, Minimize, Copy } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 
 interface ResponseDialogProps {
@@ -31,7 +31,7 @@ export const ResponseDialog: React.FC<ResponseDialogProps> = ({
     if (!ctx) return;
 
     // Set white background
-    ctx.fillStyle = "white";
+    ctx.fillStyle = "#30455c";
     ctx.fillRect(0, 0, canvas.width, canvas.height);
 
     // Draw all paths
@@ -176,7 +176,7 @@ export const ResponseDialog: React.FC<ResponseDialogProps> = ({
         >
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4 p-4">
             {/* Drawing Canvas */}
-            <div className="relative bg-white rounded-lg shadow-md overflow-hidden h-[300px] md:h-auto">
+            <div className="relative bg-30455c rounded-lg shadow-md overflow-hidden h-[300px] md:h-auto">
               <canvas
                 ref={canvasRef}
                 width={800}

--- a/src/components/Whiteboard.tsx
+++ b/src/components/Whiteboard.tsx
@@ -457,7 +457,7 @@ export const Whiteboard: React.FC = () => {
     if (!ctx) return;
 
     ctx.clearRect(0, 0, canvasElement.width, canvasElement.height);
-    ctx.fillStyle = "white";
+    ctx.fillStyle = "#1f2937";
     ctx.fillRect(0, 0, canvasElement.width, canvasElement.height);
 
     data.forEach((path) => {


### PR DESCRIPTION
Issue: On the whiteboard, if a user draws with a white pen, the strokes blend into the white canvas. This causes the AI to miss the input or give incorrect/no analysis.

Fix: Updated the canvas background used during AI capture to a dark color, ensuring white strokes are always visible. This improves accuracy of AI interpretation for all pen colors.

fixes https://github.com/tarinagarwal/learnify/issues/12#issuecomment-2922444399

## before
![Screenshot from 2025-05-30 19-41-34](https://github.com/user-attachments/assets/50724470-fa23-4e7a-ab4e-875ecb65e7e5)

## after
![Screenshot from 2025-05-30 20-33-58](https://github.com/user-attachments/assets/17f27abe-aab8-4f3b-a62b-e400ddeda98f)

![Screenshot from 2025-05-30 20-34-41](https://github.com/user-attachments/assets/89cd0e39-442d-4728-aae0-38feee35989a)
